### PR TITLE
Performance improvements and various fixes

### DIFF
--- a/lib/sequel/plugins/bulk_audit.rb
+++ b/lib/sequel/plugins/bulk_audit.rb
@@ -15,7 +15,7 @@ module Sequel
           ObjectSpace.each_object(Sequel::Model::ClassMethods).select do |klazz|
             next if klazz.name.nil?
             klazz < Sequel::Model && klazz&.plugins&.include?(Sequel::Plugins::BulkAudit)
-          end.map { |c| [c.to_s, c.implicit_table_name] }.to_h.invert
+          end.map { |c| [c.to_s, c.table_name] }.to_h.invert
         end
 
         def with_current_user(current_user, attributes = nil)

--- a/lib/sequel/plugins/bulk_audit.rb
+++ b/lib/sequel/plugins/bulk_audit.rb
@@ -25,9 +25,8 @@ module Sequel
                              Sequel.cast(current_user&.login || "unspecified", :text).as(:username),
                              Sequel.pg_jsonb(model_to_table_map).as(:model_map),
                              Sequel.pg_jsonb(attributes || {}).as(:data))
-            self.db.create_table!(:"__audit_info_#{trid}", temp: true, as: data)
+            self.db.create_table!(:"__audit_info_#{trid}", temp: true, on_commit: :drop, as: data)
             result = yield if block_given?
-            self.db.drop_table?(:"__audit_info_#{trid}")
             result
           end
         end

--- a/lib/sequel/plugins/bulk_audit.rb
+++ b/lib/sequel/plugins/bulk_audit.rb
@@ -19,13 +19,13 @@ module Sequel
         end
 
         def with_current_user(current_user, attributes = nil)
-          self.db.transaction do
-            trid = self.db.select(Sequel.function(:txid_current)).single_value
-            data = self.db.select(Sequel.expr(current_user&.id || 0).as(:user_id),
+          db.transaction do
+            trid = db.select(Sequel.function(:txid_current)).single_value
+            data = db.select(Sequel.expr(current_user&.id || 0).as(:user_id),
                              Sequel.cast(current_user&.login || "unspecified", :text).as(:username),
                              Sequel.pg_jsonb(model_to_table_map).as(:model_map),
                              Sequel.pg_jsonb(attributes || {}).as(:data))
-            self.db.create_table!(:"__audit_info_#{trid}", temp: true, on_commit: :drop, as: data)
+            db.create_table!(:"__audit_info_#{trid}", temp: true, on_commit: :drop, as: data)
             result = yield if block_given?
             result
           end

--- a/lib/sequel/plugins/bulk_audit.rb
+++ b/lib/sequel/plugins/bulk_audit.rb
@@ -12,10 +12,10 @@ module Sequel
 
       module SharedMethods
         def model_to_table_map
-          @@model_to_table_map ||= ObjectSpace.each_object(Class).select do |klazz|
+          ObjectSpace.each_object(Sequel::Model::ClassMethods).select do |klazz|
             next if klazz.name.nil?
             klazz < Sequel::Model && klazz&.plugins&.include?(Sequel::Plugins::BulkAudit)
-          end.map { |c| [c.to_s, c.table_name] }.to_h.invert
+          end.map { |c| [c.to_s, c.implicit_table_name] }.to_h.invert
         end
 
         def with_current_user(current_user, attributes = nil)


### PR DESCRIPTION
I've tried to be more descriptive as possible. Please see the commit description for why and how this fixes applied.

This PR includes:

* Limiting `ObjectSpace` to `Sequel::Model::ClassMethods` only.
* Using `drop on commit` while creating temporary tables. This will saves redundant SQL query from sending to the server.
* Adding an exception handling and returning whole row ins case of temporary table is not found in somehow.
* Removing variable cache due to fast select mechanism. This will allow all tables and models from being mapped to the database.

Please review and comment for the changes if you think there might be a different changes made.

This fixes #3.